### PR TITLE
Removes unused redisson CommandExecutor import

### DIFF
--- a/bucket4j-redis/src/main/java/io/github/bucket4j/redis/spring/cas/SpringDataRedisBasedProxyManager.java
+++ b/bucket4j-redis/src/main/java/io/github/bucket4j/redis/spring/cas/SpringDataRedisBasedProxyManager.java
@@ -29,7 +29,6 @@ import io.github.bucket4j.distributed.proxy.generic.compare_and_swap.CompareAndS
 import io.github.bucket4j.distributed.remote.RemoteBucketState;
 import io.github.bucket4j.redis.AbstractRedisProxyManagerBuilder;
 import io.github.bucket4j.redis.redisson.cas.RedissonBasedProxyManager;
-import org.redisson.command.CommandExecutor;
 import org.springframework.data.redis.connection.RedisCommands;
 import org.springframework.data.redis.connection.ReturnType;
 


### PR DESCRIPTION
Hi Vladimir,

There is an unused import on line 32 (org.redisson.command.CommandExecutor). 

I suspect this to be a typo because:
1) the import org.redisson.command.CommandExecutor is not referenced anywhere inside the class definition 
2) the class definition (SpringDataRedisBasedProxyManager) is a spring-data implementation of the ProxyManager. I would not suspect to see references to vendor-specific implementations here because you're already using the vendor-agnostic facilities provided by spring-data-redis.

My builds still run but my IDE is complaining because I don't have redisson on my classpath (this is surely the case for others as well, spring-boot-data-starter-redis only supplies jedis and lettuce).