### PR TITLE
fix(sec): upgrade com.google.guava:guava to 30.0-jre

### DIFF
--- a/bucket4j-benchmarks/pom.xml
+++ b/bucket4j-benchmarks/pom.xml
@@ -42,7 +42,7 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>18.0</version>
+            <version>30.0-jre</version>
         </dependency>
         <dependency>
             <groupId>io.github.resilience4j</groupId>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in com.google.guava:guava 18.0
- [CVE-2018-10237](https://www.oscs1024.com/hd/CVE-2018-10237)


### What did I do？
Upgrade com.google.guava:guava from 18.0 to 30.0-jre for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS