### PR TITLE
Contravariant arguments for CaffeineProxyManager

### DIFF
--- a/bucket4j-caffeine/src/main/java/io/github/bucket4j/caffeine/CaffeineProxyManager.java
+++ b/bucket4j-caffeine/src/main/java/io/github/bucket4j/caffeine/CaffeineProxyManager.java
@@ -48,11 +48,11 @@ public class CaffeineProxyManager<K> extends AbstractProxyManager<K> {
      * @param builder the builder that will be used for cache creation
      * @param keepAfterRefillDuration specifies how long bucket should be held in the cache after all consumed tokens have been refilled.
      */
-    public CaffeineProxyManager(Caffeine<K, RemoteBucketState> builder, Duration keepAfterRefillDuration) {
+    public CaffeineProxyManager(Caffeine<? super K, ? super RemoteBucketState> builder, Duration keepAfterRefillDuration) {
         this(builder, keepAfterRefillDuration, ClientSideConfig.getDefault());
     }
 
-    public CaffeineProxyManager(Caffeine<K, RemoteBucketState> builder, Duration keepAfterRefillDuration, ClientSideConfig clientSideConfig) {
+    public CaffeineProxyManager(Caffeine<? super K, ? super RemoteBucketState> builder, Duration keepAfterRefillDuration, ClientSideConfig clientSideConfig) {
         super(clientSideConfig);
         this.cache = builder
             .expireAfter(new Expiry<K, RemoteBucketState>() {

--- a/bucket4j-caffeine/src/test/java/io/github/bucket4j/caffeine/CaffeineTest.java
+++ b/bucket4j-caffeine/src/test/java/io/github/bucket4j/caffeine/CaffeineTest.java
@@ -2,7 +2,6 @@ package io.github.bucket4j.caffeine;
 
 import com.github.benmanes.caffeine.cache.Caffeine;
 import io.github.bucket4j.distributed.proxy.ProxyManager;
-import io.github.bucket4j.distributed.remote.RemoteBucketState;
 import io.github.bucket4j.tck.AbstractDistributedBucketTest;
 
 import java.time.Duration;
@@ -12,7 +11,7 @@ public class CaffeineTest extends AbstractDistributedBucketTest<String> {
 
     @Override
     protected ProxyManager<String> getProxyManager() {
-        Caffeine<String, RemoteBucketState> builder = (Caffeine) Caffeine.newBuilder().maximumSize(100);
+        Caffeine<Object, Object> builder = Caffeine.newBuilder().maximumSize(100);
         return new CaffeineProxyManager<>(builder, Duration.ofMinutes(1));
     }
 


### PR DESCRIPTION
Hi, using CaffeineProxyManager has a problem of having to cast using raw types which may not be type safe. This should improve the experience and provide some type safety for custom settings applied to the cache.