### PR TITLE
Add key mapping capability to ProxyManager

### DIFF
--- a/bucket4j-core/src/main/java/io/github/bucket4j/distributed/proxy/RemoteAsyncBucketBuilder.java
+++ b/bucket4j-core/src/main/java/io/github/bucket4j/distributed/proxy/RemoteAsyncBucketBuilder.java
@@ -123,17 +123,20 @@ public interface RemoteAsyncBucketBuilder<K> {
         return new RemoteAsyncBucketBuilder<>() {
             @Override
             public RemoteAsyncBucketBuilder<K1> withRecoveryStrategy(RecoveryStrategy recoveryStrategy) {
-                return RemoteAsyncBucketBuilder.this.withRecoveryStrategy(recoveryStrategy).withMapper(mapper);
+                RemoteAsyncBucketBuilder.this.withRecoveryStrategy(recoveryStrategy);
+                return this;
             }
 
             @Override
             public RemoteAsyncBucketBuilder<K1> withOptimization(Optimization optimization) {
-                return RemoteAsyncBucketBuilder.this.withOptimization(optimization).withMapper(mapper);
+                RemoteAsyncBucketBuilder.this.withOptimization(optimization);
+                return this;
             }
 
             @Override
             public RemoteAsyncBucketBuilder<K1> withImplicitConfigurationReplacement(long desiredConfigurationVersion, TokensInheritanceStrategy tokensInheritanceStrategy) {
-                return RemoteAsyncBucketBuilder.this.withImplicitConfigurationReplacement(desiredConfigurationVersion, tokensInheritanceStrategy).withMapper(mapper);
+                RemoteAsyncBucketBuilder.this.withImplicitConfigurationReplacement(desiredConfigurationVersion, tokensInheritanceStrategy);
+                return this;
             }
 
             @Override

--- a/bucket4j-core/src/main/java/io/github/bucket4j/distributed/proxy/RemoteAsyncBucketBuilder.java
+++ b/bucket4j-core/src/main/java/io/github/bucket4j/distributed/proxy/RemoteAsyncBucketBuilder.java
@@ -27,6 +27,7 @@ import io.github.bucket4j.distributed.proxy.optimization.Optimization;
 import io.github.bucket4j.distributed.proxy.optimization.Optimizations;
 
 import java.util.concurrent.CompletableFuture;
+import java.util.function.Function;
 import java.util.function.Supplier;
 
 /**
@@ -101,7 +102,6 @@ public interface RemoteAsyncBucketBuilder<K> {
      * is costly, for example because parameters for particular {@code key} are stored in external database,
      * {@code configurationSupplier} will be called if and only if bucket has not been persisted before.
      *
-     *
      * @param key the key that used in external storage to distinguish one bucket from another.
      * @param configurationSupplier provider for bucket configuration
      *
@@ -109,4 +109,48 @@ public interface RemoteAsyncBucketBuilder<K> {
      */
     AsyncBucketProxy build(K key, Supplier<CompletableFuture<BucketConfiguration>> configurationSupplier);
 
+
+    /**
+     * Returns a proxy object that wraps this RemoteAsyncBucketBuilder such that keys are first mapped using the specified mapping function
+     * before being sent to the remote store. The returned RemoteAsyncBucketBuilder shares the same underlying store as the original,
+     * and keys that map to the same value will share the same remote state.
+     *
+     * @param mapper the mapper function to apply to keys
+     * @return a proxy object that wraps this RemoteAsyncBucketBuilder
+     * @param <K1> the type of key accepted by returned RemoteAsyncBucketBuilder
+     */
+    default <K1> RemoteAsyncBucketBuilder<K1> withMapper(Function<? super K1, ? extends K> mapper) {
+        return new RemoteAsyncBucketBuilder<>() {
+            @Override
+            public RemoteAsyncBucketBuilder<K1> withRecoveryStrategy(RecoveryStrategy recoveryStrategy) {
+                return RemoteAsyncBucketBuilder.this.withRecoveryStrategy(recoveryStrategy).withMapper(mapper);
+            }
+
+            @Override
+            public RemoteAsyncBucketBuilder<K1> withOptimization(Optimization optimization) {
+                return RemoteAsyncBucketBuilder.this.withOptimization(optimization).withMapper(mapper);
+            }
+
+            @Override
+            public RemoteAsyncBucketBuilder<K1> withImplicitConfigurationReplacement(long desiredConfigurationVersion, TokensInheritanceStrategy tokensInheritanceStrategy) {
+                return RemoteAsyncBucketBuilder.this.withImplicitConfigurationReplacement(desiredConfigurationVersion, tokensInheritanceStrategy).withMapper(mapper);
+            }
+
+            @Override
+            public AsyncBucketProxy build(K1 key, BucketConfiguration configuration) {
+                return RemoteAsyncBucketBuilder.this.build(mapper.apply(key), configuration);
+            }
+
+            @Override
+            public AsyncBucketProxy build(K1 key, Supplier<CompletableFuture<BucketConfiguration>> configurationSupplier) {
+                return RemoteAsyncBucketBuilder.this.build(mapper.apply(key), configurationSupplier);
+            }
+
+            // To prevent nesting of anonymous class instances, directly map the original instance.
+            @Override
+            public <K2> RemoteAsyncBucketBuilder<K2> withMapper(Function<? super K2, ? extends K1> innerMapper) {
+                return RemoteAsyncBucketBuilder.this.withMapper(mapper.compose(innerMapper));
+            }
+        };
+    }
 }

--- a/bucket4j-core/src/main/java/io/github/bucket4j/distributed/proxy/RemoteBucketBuilder.java
+++ b/bucket4j-core/src/main/java/io/github/bucket4j/distributed/proxy/RemoteBucketBuilder.java
@@ -125,17 +125,20 @@ public interface RemoteBucketBuilder<K> {
         return new RemoteBucketBuilder<>() {
             @Override
             public RemoteBucketBuilder<K1> withRecoveryStrategy(RecoveryStrategy recoveryStrategy) {
-                return RemoteBucketBuilder.this.withRecoveryStrategy(recoveryStrategy).withMapper(mapper);
+                RemoteBucketBuilder.this.withRecoveryStrategy(recoveryStrategy);
+                return this;
             }
 
             @Override
             public RemoteBucketBuilder<K1> withOptimization(Optimization optimization) {
-                return RemoteBucketBuilder.this.withOptimization(optimization).withMapper(mapper);
+                RemoteBucketBuilder.this.withOptimization(optimization);
+                return this;
             }
 
             @Override
             public RemoteBucketBuilder<K1> withImplicitConfigurationReplacement(long desiredConfigurationVersion, TokensInheritanceStrategy tokensInheritanceStrategy) {
-                return RemoteBucketBuilder.this.withImplicitConfigurationReplacement(desiredConfigurationVersion, tokensInheritanceStrategy).withMapper(mapper);
+                RemoteBucketBuilder.this.withImplicitConfigurationReplacement(desiredConfigurationVersion, tokensInheritanceStrategy);
+                return this;
             }
 
             @Override


### PR DESCRIPTION
Proof of concept from discussion on #358

- Add withMapper method to ProxyManager to allow mapping any ProxyManager<K> to any other ProxyManager<K1> given an appropriate Function<K1, K>