### PR TITLE
fix(sec): upgrade org.jetbrains.kotlin:kotlin-stdlib to 

### DIFF
--- a/lincheck-tests/pom.xml
+++ b/lincheck-tests/pom.xml
@@ -15,7 +15,7 @@
         <maven.deploy.skip>true</maven.deploy.skip>
         <revapi.skip>true</revapi.skip>
         <experimentalCoroutines>enable</experimentalCoroutines>
-        <kotlin.version>1.4.0</kotlin.version>
+        <kotlin.version>1.6.0</kotlin.version>
         <lincheck.version>2.14.1</lincheck.version>
         <asm.version>9.0</asm.version>
         <maven.compiler.source>11</maven.compiler.source>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in org.jetbrains.kotlin:kotlin-stdlib 1.4.0
- [CVE-2022-24329](https://www.oscs1024.com/hd/CVE-2022-24329)


### What did I do？
Upgrade org.jetbrains.kotlin:kotlin-stdlib from 1.4.0 to  for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS