### PR TITLE
Update redisson proxy manager to support redisson 3.21.0

### DIFF
--- a/bucket4j-parent/pom.xml
+++ b/bucket4j-parent/pom.xml
@@ -58,7 +58,7 @@
         <testcontainers.version>1.17.1</testcontainers.version>
         <lettuce-version>5.0.2.RELEASE</lettuce-version>
         <jedis.version>4.2.3</jedis.version>
-        <redisson.version>3.16.8</redisson.version>
+        <redisson.version>3.21.0</redisson.version>
         <lettuce.version>6.1.8.RELEASE</lettuce.version>
         <caffeine.version>2.9.3</caffeine.version>
     </properties>

--- a/bucket4j-redis/src/test/java/io/github/bucket4j/redis/redisson/cas/RedissonBasedProxyManagerFixedTtlTest.java
+++ b/bucket4j-redis/src/test/java/io/github/bucket4j/redis/redisson/cas/RedissonBasedProxyManagerFixedTtlTest.java
@@ -6,11 +6,12 @@ import io.github.bucket4j.distributed.proxy.ProxyManager;
 import io.github.bucket4j.tck.AbstractDistributedBucketTest;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
-import org.redisson.command.CommandExecutor;
-import org.redisson.command.CommandSyncService;
+import org.redisson.command.CommandAsyncExecutor;
+import org.redisson.command.CommandAsyncService;
 import org.redisson.config.Config;
 import org.redisson.config.ConfigSupport;
 import org.redisson.connection.ConnectionManager;
+import org.redisson.liveobject.core.RedissonObjectBuilder;
 import org.testcontainers.containers.GenericContainer;
 
 import java.time.Duration;
@@ -20,7 +21,7 @@ public class RedissonBasedProxyManagerFixedTtlTest extends AbstractDistributedBu
 
     private static GenericContainer container;
     private static ConnectionManager connectionManager;
-    private static CommandExecutor commandExecutor;
+    private static CommandAsyncExecutor commandExecutor;
 
     @BeforeClass
     public static void setup() {
@@ -51,8 +52,8 @@ public class RedissonBasedProxyManagerFixedTtlTest extends AbstractDistributedBu
         return connectionManager;
     }
 
-    private static CommandExecutor createRedissonExecutor(ConnectionManager connectionManager) {
-        return new CommandSyncService(connectionManager, null);
+    private static CommandAsyncExecutor createRedissonExecutor(ConnectionManager connectionManager) {
+        return new CommandAsyncService(connectionManager, null, RedissonObjectBuilder.ReferenceType.DEFAULT);
     }
 
     private static GenericContainer startRedisContainer() {

--- a/bucket4j-redis/src/test/java/io/github/bucket4j/redis/redisson/cas/RedissonBasedProxyManagerTest.java
+++ b/bucket4j-redis/src/test/java/io/github/bucket4j/redis/redisson/cas/RedissonBasedProxyManagerTest.java
@@ -6,11 +6,12 @@ import io.github.bucket4j.distributed.proxy.ClientSideConfig;
 import io.github.bucket4j.tck.AbstractDistributedBucketTest;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
-import org.redisson.command.CommandExecutor;
-import org.redisson.command.CommandSyncService;
+import org.redisson.command.CommandAsyncExecutor;
+import org.redisson.command.CommandAsyncService;
 import org.redisson.config.Config;
 import org.redisson.config.ConfigSupport;
 import org.redisson.connection.ConnectionManager;
+import org.redisson.liveobject.core.RedissonObjectBuilder;
 import org.testcontainers.containers.GenericContainer;
 
 import java.util.UUID;
@@ -19,7 +20,7 @@ public class RedissonBasedProxyManagerTest extends AbstractDistributedBucketTest
 
     private static GenericContainer container;
     private static ConnectionManager connectionManager;
-    private static CommandExecutor commandExecutor;
+    private static CommandAsyncExecutor commandExecutor;
 
     @BeforeClass
     public static void setup() {
@@ -50,8 +51,8 @@ public class RedissonBasedProxyManagerTest extends AbstractDistributedBucketTest
         return connectionManager;
     }
 
-    private static CommandExecutor createRedissonExecutor(ConnectionManager connectionManager) {
-        return new CommandSyncService(connectionManager, null);
+    private static CommandAsyncExecutor createRedissonExecutor(ConnectionManager connectionManager) {
+        return new CommandAsyncService(connectionManager, null, RedissonObjectBuilder.ReferenceType.DEFAULT);
     }
 
     private static GenericContainer startRedisContainer() {


### PR DESCRIPTION
The synchronous command executor has been [removed](https://github.com/redisson/redisson/commit/4b1a76eb9a4415a81bffdc04254a59fa4c7a85fb) from Redisson in version 3.21.0.