### PR TITLE
Updated API for arbitrary Key types in LettuceBasedProxyManager without Mapper

### DIFF
--- a/bucket4j-redis/src/test/java/io/github/bucket4j/redis/lettuce/cas/LettuceBasedProxyManager_StringKey_Test.java
+++ b/bucket4j-redis/src/test/java/io/github/bucket4j/redis/lettuce/cas/LettuceBasedProxyManager_StringKey_Test.java
@@ -2,14 +2,15 @@ package io.github.bucket4j.redis.lettuce.cas;
 
 import io.github.bucket4j.distributed.ExpirationAfterWriteStrategy;
 import io.github.bucket4j.distributed.proxy.ProxyManager;
-import io.github.bucket4j.distributed.serialization.Mapper;
 import io.github.bucket4j.tck.AbstractDistributedBucketTest;
 import io.lettuce.core.RedisClient;
+import io.lettuce.core.codec.ByteArrayCodec;
+import io.lettuce.core.codec.RedisCodec;
+import io.lettuce.core.codec.StringCodec;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.testcontainers.containers.GenericContainer;
 
-import java.nio.charset.StandardCharsets;
 import java.util.UUID;
 
 public class LettuceBasedProxyManager_StringKey_Test extends AbstractDistributedBucketTest<String> {
@@ -49,9 +50,8 @@ public class LettuceBasedProxyManager_StringKey_Test extends AbstractDistributed
 
     @Override
     protected ProxyManager<String> getProxyManager() {
-        return LettuceBasedProxyManager.builderFor(redisClient)
+        return LettuceBasedProxyManager.builderFor(redisClient.connect(RedisCodec.of(StringCodec.UTF8, ByteArrayCodec.INSTANCE)))
                 .withExpirationStrategy(ExpirationAfterWriteStrategy.none())
-                .withKeyMapper(Mapper.STRING)
                 .build();
     }
 


### PR DESCRIPTION
Hi @vladimir-bukhtoyarov 

We recently discussed allowing for arbitrary key types for Redis Proxy Managers here https://github.com/bucket4j/bucket4j/discussions/358

As part of the discussion, you made it clear we wanted to rely on external APIs as much as possible, and with this I agree.

For Lettuce however, an option that just came to me recently was that if Bucket4J were not to be responsible for defining a RedisCodec that would define how the keys would be serialized, an option would be to still allow the user to define their own RedisConnectoon. This would allow people to create their LettuceProxyManager using any connection they may already have defined as long as it allows for byte array value type, instead of having to use Bucket4J Mapper class and creating additional dependency.

Doing this does not add any more dependency to Bucket4J on external APIs, but opening up the generic typing gives a bit more flexibility to users.

And if someone still really needed to map their keys instead of going via a RedisCodec, they can use this change https://github.com/bucket4j/bucket4j/pull/360