### PR TITLE
Implement UnifiedJedis builder for JedisBasedProxyManager

### DIFF
--- a/bucket4j-parent/pom.xml
+++ b/bucket4j-parent/pom.xml
@@ -57,7 +57,7 @@
 
         <testcontainers.version>1.18.1</testcontainers.version>
         <lettuce-version>5.0.2.RELEASE</lettuce-version>
-        <jedis.version>4.2.3</jedis.version>
+        <jedis.version>4.4.6</jedis.version>
         <redisson.version>3.21.0</redisson.version>
         <lettuce.version>6.1.8.RELEASE</lettuce.version>
         <caffeine.version>2.9.3</caffeine.version>

--- a/bucket4j-redis/src/main/java/io/github/bucket4j/redis/jedis/cas/JedisBasedProxyManager.java
+++ b/bucket4j-redis/src/main/java/io/github/bucket4j/redis/jedis/cas/JedisBasedProxyManager.java
@@ -31,6 +31,7 @@ import io.github.bucket4j.redis.AbstractRedisProxyManagerBuilder;
 import io.github.bucket4j.redis.consts.LuaScripts;
 import redis.clients.jedis.Jedis;
 import redis.clients.jedis.JedisCluster;
+import redis.clients.jedis.UnifiedJedis;
 import redis.clients.jedis.util.Pool;
 
 import java.nio.charset.StandardCharsets;
@@ -67,6 +68,28 @@ public class JedisBasedProxyManager<K> extends AbstractCompareAndSwapBasedProxyM
             }
         };
         return new JedisBasedProxyManagerBuilder<>(Mapper.BYTES, redisApi);
+    }
+
+    public static JedisBasedProxyManagerBuilder<byte[]> builderFor(UnifiedJedis unifiedJedis) {
+        Objects.requireNonNull(unifiedJedis);
+        RedisApi redisApi = new RedisApi() {
+            @Override
+            public Object eval(byte[] script, int keyCount, byte[]... params) {
+                return unifiedJedis.eval(script, keyCount, params);
+            }
+
+            @Override
+            public byte[] get(byte[] key) {
+                return unifiedJedis.get(key);
+            }
+
+            @Override
+            public void delete(byte[] key) {
+                unifiedJedis.del(key);
+            }
+        };
+        return new JedisBasedProxyManagerBuilder<>(Mapper.BYTES, redisApi);
+
     }
 
     public static JedisBasedProxyManagerBuilder<byte[]> builderFor(JedisCluster jedisCluster) {

--- a/bucket4j-redis/src/test/java/io/github/bucket4j/redis/jedis/cas/JedisProxyManager_UnifiedJedis_JedisPooled_Test.java
+++ b/bucket4j-redis/src/test/java/io/github/bucket4j/redis/jedis/cas/JedisProxyManager_UnifiedJedis_JedisPooled_Test.java
@@ -1,0 +1,59 @@
+package io.github.bucket4j.redis.jedis.cas;
+
+import io.github.bucket4j.distributed.ExpirationAfterWriteStrategy;
+import io.github.bucket4j.distributed.proxy.ProxyManager;
+import io.github.bucket4j.tck.AbstractDistributedBucketTest;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.testcontainers.containers.GenericContainer;
+import redis.clients.jedis.JedisPooled;
+import redis.clients.jedis.UnifiedJedis;
+
+import java.nio.charset.StandardCharsets;
+import java.util.UUID;
+
+public class JedisProxyManager_UnifiedJedis_JedisPooled_Test extends AbstractDistributedBucketTest<byte[]> {
+    private static GenericContainer container;
+    private static UnifiedJedis unifiedJedis;
+
+    @BeforeAll
+    public static void setup() {
+        container = startRedisContainer();
+        unifiedJedis = createUnifiedJedisClient(container);
+    }
+
+    @AfterAll
+    public static void shutdown() {
+        if (unifiedJedis != null) {
+            unifiedJedis.close();
+        }
+        if (container != null) {
+            container.close();
+        }
+    }
+
+    private static UnifiedJedis createUnifiedJedisClient(GenericContainer container) {
+        String redisHost = container.getHost();
+        Integer redisPort = container.getMappedPort(6379);
+
+        return new JedisPooled(redisHost, redisPort);
+    }
+
+    private static GenericContainer startRedisContainer() {
+        GenericContainer genericContainer = new GenericContainer("redis:7.0.2").withExposedPorts(6379);
+        genericContainer.start();
+        return genericContainer;
+    }
+
+    @Override
+    protected ProxyManager<byte[]> getProxyManager() {
+        return JedisBasedProxyManager.builderFor(unifiedJedis)
+                .withExpirationStrategy(ExpirationAfterWriteStrategy.none())
+                .build();
+    }
+
+    @Override
+    protected byte[] generateRandomKey() {
+        return UUID.randomUUID().toString().getBytes(StandardCharsets.UTF_8);
+    }
+}

--- a/bucket4j-redis/src/test/java/io/github/bucket4j/redis/jedis/cas/JedisProxyManager_UnifiedJedis_Test.java
+++ b/bucket4j-redis/src/test/java/io/github/bucket4j/redis/jedis/cas/JedisProxyManager_UnifiedJedis_Test.java
@@ -1,0 +1,59 @@
+package io.github.bucket4j.redis.jedis.cas;
+
+import io.github.bucket4j.distributed.ExpirationAfterWriteStrategy;
+import io.github.bucket4j.distributed.proxy.ProxyManager;
+import io.github.bucket4j.tck.AbstractDistributedBucketTest;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.testcontainers.containers.GenericContainer;
+import redis.clients.jedis.HostAndPort;
+import redis.clients.jedis.UnifiedJedis;
+
+import java.nio.charset.StandardCharsets;
+import java.util.UUID;
+
+public class JedisProxyManager_UnifiedJedis_Test extends AbstractDistributedBucketTest<byte[]> {
+    private static GenericContainer container;
+    private static UnifiedJedis unifiedJedis;
+
+    @BeforeAll
+    public static void setup() {
+        container = startRedisContainer();
+        unifiedJedis = createUnifiedJedisClient(container);
+    }
+
+    @AfterAll
+    public static void shutdown() {
+        if (unifiedJedis != null) {
+            unifiedJedis.close();
+        }
+        if (container != null) {
+            container.close();
+        }
+    }
+
+    private static UnifiedJedis createUnifiedJedisClient(GenericContainer container) {
+        String redisHost = container.getHost();
+        Integer redisPort = container.getMappedPort(6379);
+
+        return new UnifiedJedis(HostAndPort.from(redisHost + ":" + redisPort));
+    }
+
+    private static GenericContainer startRedisContainer() {
+        GenericContainer genericContainer = new GenericContainer("redis:7.0.2").withExposedPorts(6379);
+        genericContainer.start();
+        return genericContainer;
+    }
+
+    @Override
+    protected ProxyManager<byte[]> getProxyManager() {
+        return JedisBasedProxyManager.builderFor(unifiedJedis)
+                .withExpirationStrategy(ExpirationAfterWriteStrategy.none())
+                .build();
+    }
+
+    @Override
+    protected byte[] generateRandomKey() {
+        return UUID.randomUUID().toString().getBytes(StandardCharsets.UTF_8);
+    }
+}


### PR DESCRIPTION
This implements support for Jedis's `UnifiedJedis` interface in `JedisBasedProxyManager`. Makes it simpler to work with various Redis setups.

I didn't bother including another test for clustered mode as the underlying class, `JedisCluster` is the same. Let me know if it'd be preferred to add a separate test where we wrap it in `UnifiedJedis` before running the test