### PR TITLE
Added parameterless ctor to the Serializers to allow load them from hazelcast standard config file.

### DIFF
--- a/bucket4j-hazelcast-all/bucket4j-hazelcast/pom.xml
+++ b/bucket4j-hazelcast-all/bucket4j-hazelcast/pom.xml
@@ -44,6 +44,12 @@
             <version>${hazelcast.latest.version}</version>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>org.junit-pioneer</groupId>
+            <artifactId>junit-pioneer</artifactId>
+            <version>2.2.0</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     
 </project>

--- a/bucket4j-hazelcast-all/bucket4j-hazelcast/src/main/java/io/github/bucket4j/grid/hazelcast/HazelcastProxyManager.java
+++ b/bucket4j-hazelcast-all/bucket4j-hazelcast/src/main/java/io/github/bucket4j/grid/hazelcast/HazelcastProxyManager.java
@@ -46,6 +46,7 @@ import io.github.bucket4j.distributed.remote.Request;
 import io.github.bucket4j.distributed.versioning.Version;
 import io.github.bucket4j.grid.hazelcast.serialization.HazelcastEntryProcessorSerializer;
 import io.github.bucket4j.grid.hazelcast.serialization.HazelcastOffloadableEntryProcessorSerializer;
+import io.github.bucket4j.grid.hazelcast.serialization.SerializationUtilities;
 import io.github.bucket4j.grid.hazelcast.serialization.SimpleBackupProcessorSerializer;
 import io.github.bucket4j.distributed.serialization.InternalSerializationHelper;
 
@@ -137,19 +138,19 @@ public class HazelcastProxyManager<K> extends AbstractProxyManager<K> {
     public static void addCustomSerializers(SerializationConfig serializationConfig, final int typeIdBase) {
         serializationConfig.addSerializerConfig(
                 new SerializerConfig()
-                        .setImplementation(new HazelcastEntryProcessorSerializer(typeIdBase))
+                        .setImplementation(new HazelcastEntryProcessorSerializer(SerializationUtilities.getSerializerTypeId(HazelcastEntryProcessorSerializer.class, typeIdBase)))
                         .setTypeClass(HazelcastEntryProcessor.class)
         );
 
         serializationConfig.addSerializerConfig(
                 new SerializerConfig()
-                        .setImplementation(new SimpleBackupProcessorSerializer(typeIdBase + 1))
+                        .setImplementation(new SimpleBackupProcessorSerializer(SerializationUtilities.getSerializerTypeId(SimpleBackupProcessorSerializer.class, typeIdBase)))
                         .setTypeClass(SimpleBackupProcessor.class)
         );
 
         serializationConfig.addSerializerConfig(
                 new SerializerConfig()
-                        .setImplementation(new HazelcastOffloadableEntryProcessorSerializer(typeIdBase + 2))
+                        .setImplementation(new HazelcastOffloadableEntryProcessorSerializer(SerializationUtilities.getSerializerTypeId(HazelcastOffloadableEntryProcessorSerializer.class, typeIdBase)))
                         .setTypeClass(HazelcastOffloadableEntryProcessor.class)
         );
 

--- a/bucket4j-hazelcast-all/bucket4j-hazelcast/src/main/java/io/github/bucket4j/grid/hazelcast/serialization/HazelcastEntryProcessorSerializer.java
+++ b/bucket4j-hazelcast-all/bucket4j-hazelcast/src/main/java/io/github/bucket4j/grid/hazelcast/serialization/HazelcastEntryProcessorSerializer.java
@@ -35,6 +35,9 @@ public class HazelcastEntryProcessorSerializer implements StreamSerializer<Hazel
     public HazelcastEntryProcessorSerializer(int typeId) {
         this.typeId = typeId;
     }
+    public HazelcastEntryProcessorSerializer() {
+        this.typeId = SerializationUtilities.getSerializerTypeId(this.getClass());
+    }
 
     public Class<HazelcastEntryProcessor> getSerializableType() {
         return HazelcastEntryProcessor.class;

--- a/bucket4j-hazelcast-all/bucket4j-hazelcast/src/main/java/io/github/bucket4j/grid/hazelcast/serialization/HazelcastOffloadableEntryProcessorSerializer.java
+++ b/bucket4j-hazelcast-all/bucket4j-hazelcast/src/main/java/io/github/bucket4j/grid/hazelcast/serialization/HazelcastOffloadableEntryProcessorSerializer.java
@@ -36,6 +36,9 @@ public class HazelcastOffloadableEntryProcessorSerializer implements StreamSeria
     public HazelcastOffloadableEntryProcessorSerializer(int typeId) {
         this.typeId = typeId;
     }
+    public HazelcastOffloadableEntryProcessorSerializer() {
+        this.typeId = SerializationUtilities.getSerializerTypeId(this.getClass());
+    }
 
     public Class<HazelcastEntryProcessor> getSerializableType() {
         return HazelcastEntryProcessor.class;

--- a/bucket4j-hazelcast-all/bucket4j-hazelcast/src/main/java/io/github/bucket4j/grid/hazelcast/serialization/InvalidConfigurationParameterException.java
+++ b/bucket4j-hazelcast-all/bucket4j-hazelcast/src/main/java/io/github/bucket4j/grid/hazelcast/serialization/InvalidConfigurationParameterException.java
@@ -1,0 +1,66 @@
+package io.github.bucket4j.grid.hazelcast.serialization;
+
+/**
+ * Thrown to indicate that an expected Parameter (both from System Parameters or Environment Variables)
+ * is invalid.
+ *
+ * @author  MonDeveloper
+ */
+public class InvalidConfigurationParameterException extends RuntimeException {
+
+        /**
+     * Constructs an <code>IllegalArgumentException</code> with no
+     * detail message.
+     */
+    public InvalidConfigurationParameterException() {
+        super();
+    }
+
+    /**
+     * Constructs an <code>IllegalArgumentException</code> with the
+     * specified detail message.
+     *
+     * @param   s   the detail message.
+     */
+    public InvalidConfigurationParameterException(String s) {
+        super(s);
+    }
+
+    /**
+     * Constructs a new exception with the specified detail message and
+     * cause.
+     *
+     * <p>Note that the detail message associated with <code>cause</code> is
+     * <i>not</i> automatically incorporated in this exception's detail
+     * message.
+     *
+     * @param  message the detail message (which is saved for later retrieval
+     *         by the {@link Throwable#getMessage()} method).
+     * @param  cause the cause (which is saved for later retrieval by the
+     *         {@link Throwable#getCause()} method).  (A {@code null} value
+     *         is permitted, and indicates that the cause is nonexistent or
+     *         unknown.)
+     * @since 1.5
+     */
+    public InvalidConfigurationParameterException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    /**
+     * Constructs a new exception with the specified cause and a detail
+     * message of {@code (cause==null ? null : cause.toString())} (which
+     * typically contains the class and detail message of {@code cause}).
+     * This constructor is useful for exceptions that are little more than
+     * wrappers for other throwables (for example, {@link
+     * java.security.PrivilegedActionException}).
+     *
+     * @param  cause the cause (which is saved for later retrieval by the
+     *         {@link Throwable#getCause()} method).  (A {@code null} value is
+     *         permitted, and indicates that the cause is nonexistent or
+     *         unknown.)
+     * @since  1.5
+     */
+    public InvalidConfigurationParameterException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/bucket4j-hazelcast-all/bucket4j-hazelcast/src/main/java/io/github/bucket4j/grid/hazelcast/serialization/MissingConfigurationParameterException.java
+++ b/bucket4j-hazelcast-all/bucket4j-hazelcast/src/main/java/io/github/bucket4j/grid/hazelcast/serialization/MissingConfigurationParameterException.java
@@ -1,0 +1,66 @@
+package io.github.bucket4j.grid.hazelcast.serialization;
+
+/**
+ * Thrown to indicate that an expected Parameter (both from System Parameters or Environment Variables)
+ * is missing.
+ *
+ * @author  MonDeveloper
+ */
+public class MissingConfigurationParameterException extends RuntimeException {
+
+        /**
+     * Constructs an <code>IllegalArgumentException</code> with no
+     * detail message.
+     */
+    public MissingConfigurationParameterException() {
+        super();
+    }
+
+    /**
+     * Constructs an <code>IllegalArgumentException</code> with the
+     * specified detail message.
+     *
+     * @param   s   the detail message.
+     */
+    public MissingConfigurationParameterException(String s) {
+        super(s);
+    }
+
+    /**
+     * Constructs a new exception with the specified detail message and
+     * cause.
+     *
+     * <p>Note that the detail message associated with <code>cause</code> is
+     * <i>not</i> automatically incorporated in this exception's detail
+     * message.
+     *
+     * @param  message the detail message (which is saved for later retrieval
+     *         by the {@link Throwable#getMessage()} method).
+     * @param  cause the cause (which is saved for later retrieval by the
+     *         {@link Throwable#getCause()} method).  (A {@code null} value
+     *         is permitted, and indicates that the cause is nonexistent or
+     *         unknown.)
+     * @since 1.5
+     */
+    public MissingConfigurationParameterException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    /**
+     * Constructs a new exception with the specified cause and a detail
+     * message of {@code (cause==null ? null : cause.toString())} (which
+     * typically contains the class and detail message of {@code cause}).
+     * This constructor is useful for exceptions that are little more than
+     * wrappers for other throwables (for example, {@link
+     * java.security.PrivilegedActionException}).
+     *
+     * @param  cause the cause (which is saved for later retrieval by the
+     *         {@link Throwable#getCause()} method).  (A {@code null} value is
+     *         permitted, and indicates that the cause is nonexistent or
+     *         unknown.)
+     * @since  1.5
+     */
+    public MissingConfigurationParameterException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/bucket4j-hazelcast-all/bucket4j-hazelcast/src/main/java/io/github/bucket4j/grid/hazelcast/serialization/SerializationUtilities.java
+++ b/bucket4j-hazelcast-all/bucket4j-hazelcast/src/main/java/io/github/bucket4j/grid/hazelcast/serialization/SerializationUtilities.java
@@ -1,0 +1,84 @@
+package io.github.bucket4j.grid.hazelcast.serialization;
+
+import com.hazelcast.internal.util.StringUtil;
+import com.hazelcast.nio.serialization.Serializer;
+
+import java.text.MessageFormat;
+import java.util.*;
+import java.util.function.Supplier;
+
+public class SerializationUtilities {
+    public static final String TYPE_ID_BASE_PROP_NAME = "Bucket4jSerializers_TypeId_Base";
+    private static final Map<Class<? extends Serializer>, Integer> serializerTypeIdOffsets = Map.ofEntries(
+            new AbstractMap.SimpleEntry<Class<? extends Serializer>, Integer>(HazelcastEntryProcessorSerializer.class, 0),
+            new AbstractMap.SimpleEntry<Class<? extends Serializer>, Integer>(SimpleBackupProcessorSerializer.class, 1),
+            new AbstractMap.SimpleEntry<Class<? extends Serializer>, Integer>(HazelcastOffloadableEntryProcessorSerializer.class, 2)
+    );
+
+    public static int getSerializerTypeId(Class<? extends Serializer> serializerType) {
+        var typeIdBase = getSerializersTypeIdBase();
+
+        if (typeIdBase.isEmpty()) {
+            String msg = MessageFormat.format("Missing TypeIdBase number, impossible to load Bucket4j custom serializers. It must be provided in form of Environment Variable or System Property, both using the following key: [{0}]", TYPE_ID_BASE_PROP_NAME);
+            throw new MissingConfigurationParameterException(msg);
+        }
+
+        return getSerializerTypeId(serializerType, typeIdBase.get());
+    }
+
+    public static int getSerializerTypeId(Class<? extends Serializer> serializerType, int typeIdBase) {
+        return typeIdBase + SerializationUtilities.getSerializerTypeIdOffset(serializerType);
+    }
+
+    private static Optional<Integer> getSerializersTypeIdBase() {
+        return Optional.ofNullable(
+                getSerializerTypeIdBaseFromSystemProperty()
+                        .orElseGet(() -> getSerializerTypeIdBaseFromEnvironmentVariable()
+                                .orElseGet(() -> null)));
+    }
+
+    private static int getSerializerTypeIdOffset(Class<? extends Serializer> serializerType) {
+        if (serializerTypeIdOffsets.containsKey(serializerType)) {
+            return serializerTypeIdOffsets.get(serializerType);
+        } else {
+            String msg = MessageFormat.format("The internal configuration does not include any offset for the serializerType [{0}]", serializerType);
+            throw new IllegalStateException(msg);
+        }
+    }
+
+    private static Optional<Integer> getSerializerTypeIdBaseFromEnvironmentVariable() {
+        return getPropertyValueFromExternal(() -> System.getenv(SerializationUtilities.TYPE_ID_BASE_PROP_NAME), "Environment Variable");
+    }
+
+    private static Optional<Integer> getSerializerTypeIdBaseFromSystemProperty() {
+        return getPropertyValueFromExternal(() -> System.getProperty(SerializationUtilities.TYPE_ID_BASE_PROP_NAME), "System Property");
+    }
+
+    private static Optional<Integer> getPropertyValueFromExternal(Supplier<String> typeIdSupplier, String source) {
+        Optional<Integer> retVal = Optional.empty();
+
+        String typeIdBaseStr = typeIdSupplier.get();
+        if (!StringUtil.isNullOrEmptyAfterTrim(typeIdBaseStr)) {
+            retVal = parseInteger(typeIdBaseStr);
+            if (retVal.isEmpty()) {
+                String msg = MessageFormat.format("The {0} [{1}] has an invalid format. It must be a positive Integer.", source, TYPE_ID_BASE_PROP_NAME);
+                throw new InvalidConfigurationParameterException(msg);
+            }
+        }
+
+        return retVal;
+    }
+
+    private static Optional<Integer> parseInteger(String strNum) {
+        Optional<Integer> retVal = Optional.empty();
+        if (null != strNum) {
+            try {
+                Integer d = Integer.parseInt(strNum.trim());
+                retVal = Optional.of(d);
+            } catch (NumberFormatException nfe) {
+                retVal = Optional.empty();
+            }
+        }
+        return retVal;
+    }
+}

--- a/bucket4j-hazelcast-all/bucket4j-hazelcast/src/main/java/io/github/bucket4j/grid/hazelcast/serialization/SimpleBackupProcessorSerializer.java
+++ b/bucket4j-hazelcast-all/bucket4j-hazelcast/src/main/java/io/github/bucket4j/grid/hazelcast/serialization/SimpleBackupProcessorSerializer.java
@@ -35,6 +35,9 @@ public class SimpleBackupProcessorSerializer implements StreamSerializer<SimpleB
     public SimpleBackupProcessorSerializer(int typeId) {
         this.typeId = typeId;
     }
+    public SimpleBackupProcessorSerializer() {
+        this.typeId = SerializationUtilities.getSerializerTypeId(this.getClass());
+    }
 
     public Class<SimpleBackupProcessor> getSerializableType() {
         return SimpleBackupProcessor.class;

--- a/bucket4j-hazelcast-all/bucket4j-hazelcast/src/test/java/io/github/bucket4j/hazelcast/HazelcastWithCustomSerializersLoadedByStandardConfigTest.java
+++ b/bucket4j-hazelcast-all/bucket4j-hazelcast/src/test/java/io/github/bucket4j/hazelcast/HazelcastWithCustomSerializersLoadedByStandardConfigTest.java
@@ -1,0 +1,125 @@
+package io.github.bucket4j.hazelcast;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.config.JoinConfig;
+import com.hazelcast.config.SerializerConfig;
+import com.hazelcast.core.Hazelcast;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.map.IMap;
+import groovy.util.logging.Slf4j;
+import io.github.bucket4j.distributed.proxy.ClientSideConfig;
+import io.github.bucket4j.distributed.serialization.JsonOutputSerializationTest;
+import io.github.bucket4j.grid.hazelcast.HazelcastEntryProcessor;
+import io.github.bucket4j.grid.hazelcast.HazelcastOffloadableEntryProcessor;
+import io.github.bucket4j.grid.hazelcast.HazelcastProxyManager;
+import io.github.bucket4j.grid.hazelcast.SimpleBackupProcessor;
+import io.github.bucket4j.grid.hazelcast.serialization.HazelcastEntryProcessorSerializer;
+import io.github.bucket4j.grid.hazelcast.serialization.HazelcastOffloadableEntryProcessorSerializer;
+import io.github.bucket4j.grid.hazelcast.serialization.SerializationUtilities;
+import io.github.bucket4j.grid.hazelcast.serialization.SimpleBackupProcessorSerializer;
+import io.github.bucket4j.tck.AbstractDistributedBucketTest;
+import io.github.bucket4j.tck.ProxyManagerSpec;
+import org.gridkit.nanocloud.Cloud;
+import org.gridkit.nanocloud.CloudFactory;
+import org.gridkit.nanocloud.VX;
+import org.gridkit.vicluster.ViNode;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junitpioneer.jupiter.SetSystemProperty;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.UUID;
+
+public class HazelcastWithCustomSerializersLoadedByStandardConfigTest extends AbstractDistributedBucketTest {
+
+    private static final Logger logger = LoggerFactory.getLogger(HazelcastWithCustomSerializersLoadedByStandardConfigTest.class);
+
+    private static IMap<String, byte[]> map;
+    private static Cloud cloud;
+    private static ViNode server;
+
+    private static HazelcastInstance hazelcastInstance;
+
+    @BeforeAll
+    public static void setup() {
+        // start separated JVM on current host
+        cloud = CloudFactory.createCloud();
+        cloud.node("**").x(VX.TYPE).setLocal();
+        server = cloud.node("stateful-hazelcast-server");
+
+        server.exec((Runnable & Serializable) () -> {
+            Config config = new Config();
+
+            // Added here the System Property (or the Env Var) as it could happen with the standalone cluster
+            System.setProperty(SerializationUtilities.TYPE_ID_BASE_PROP_NAME, "10000");
+            String testSP = System.getProperty(SerializationUtilities.TYPE_ID_BASE_PROP_NAME);
+            logger.info("The System Property [{}] has the following value [{}]", SerializationUtilities.TYPE_ID_BASE_PROP_NAME, testSP);
+
+            // *******************************************************************************************************
+            // with this block we are simulating the load of the hazelcast config by the config_file since we are using only the
+            // serializer parameterless constructor as it required by the config file
+            config.getSerializationConfig().addSerializerConfig(
+                    new SerializerConfig()
+                            .setClass(HazelcastEntryProcessorSerializer.class)
+                            .setTypeClass(HazelcastEntryProcessor.class)
+            );
+            config.getSerializationConfig().addSerializerConfig(
+                    new SerializerConfig()
+                            .setClass(SimpleBackupProcessorSerializer.class)
+                            .setTypeClass(SimpleBackupProcessor.class)
+            );
+            config.getSerializationConfig().addSerializerConfig(
+                    new SerializerConfig()
+                            .setClass(HazelcastOffloadableEntryProcessorSerializer.class)
+                            .setTypeClass(HazelcastOffloadableEntryProcessor.class)
+            );
+            // *******************************************************************************************************
+
+            JoinConfig joinConfig = config.getNetworkConfig().getJoin();
+            joinConfig.getMulticastConfig().setEnabled(false);
+            joinConfig.getTcpIpConfig().setEnabled(true);
+            joinConfig.getTcpIpConfig().addMember("127.0.0.1:5702");
+            config.setLiteMember(false);
+            HazelcastInstance hazelcastInstance = Hazelcast.newHazelcastInstance(config);
+            hazelcastInstance.getMap("my_buckets");
+        });
+
+        // start hazelcast client which works inside current JVM and does not hold data
+        Config config = new Config();
+        JoinConfig joinConfig = config.getNetworkConfig().getJoin();
+        joinConfig.getMulticastConfig().setEnabled(false);
+        joinConfig.getTcpIpConfig().setEnabled(true);
+        joinConfig.getTcpIpConfig().addMember("127.0.0.1:5701");
+        HazelcastProxyManager.addCustomSerializers(config.getSerializationConfig(), 10_000);
+        config.setLiteMember(true);
+        hazelcastInstance = Hazelcast.newHazelcastInstance(config);
+        map = hazelcastInstance.getMap("my_buckets");
+
+        specs = Arrays.asList(
+            new ProxyManagerSpec<>(
+                "HazelcastProxyManager_CustomSerialization",
+                () -> UUID.randomUUID().toString(),
+                new HazelcastProxyManager<>(map, ClientSideConfig.getDefault())
+            ),
+            new ProxyManagerSpec<>(
+                "HazelcastLockBasedProxyManager_JdkSerialization_offloadableExecutor",
+                () -> UUID.randomUUID().toString(),
+                new HazelcastProxyManager<>(map, ClientSideConfig.getDefault(), "my-executor")
+            )
+        );
+    }
+
+    @AfterAll
+    public static void shutdown() {
+        if (hazelcastInstance != null) {
+            hazelcastInstance.shutdown();
+        }
+        if (cloud != null) {
+            cloud.shutdown();
+        }
+    }
+
+}

--- a/bucket4j-hazelcast-all/bucket4j-hazelcast/src/test/java/io/github/bucket4j/hazelcast/SerializationUtilitiesTest.java
+++ b/bucket4j-hazelcast-all/bucket4j-hazelcast/src/test/java/io/github/bucket4j/hazelcast/SerializationUtilitiesTest.java
@@ -1,0 +1,156 @@
+package io.github.bucket4j.hazelcast;
+
+import com.hazelcast.internal.serialization.impl.defaultserializers.ArrayBlockingQueueStreamSerializer;
+import io.github.bucket4j.grid.hazelcast.serialization.*;
+import org.junit.jupiter.api.Test;
+import org.junitpioneer.jupiter.ClearEnvironmentVariable;
+import org.junitpioneer.jupiter.ClearSystemProperty;
+import org.junitpioneer.jupiter.SetEnvironmentVariable;
+import org.junitpioneer.jupiter.SetSystemProperty;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class SerializationUtilitiesTest {
+
+    private static final String TYPE_ID_BASE_ENV_VAR_VALUE_VALID = "12345";
+    private static final String TYPE_ID_BASE_ENV_VAR_VALUE_INVALID = "12?45";
+    private static final String TYPE_ID_BASE_SYS_PROP_VALUE_VALID = "56789";
+    private static final String TYPE_ID_BASE_SYS_PROP_VALUE_INVALID = "56?89";
+
+    // ************************************************************************************
+    // TYPE_ID
+    // Read each, for expected and unexpected serializers 
+    // ************************************************************************************
+    @Test
+    public void SerializationUtilities_Expected_Serializers_with_explicit_typeIdBase_Test() {
+        assertEquals(10, SerializationUtilities.getSerializerTypeId(HazelcastEntryProcessorSerializer.class, 10));
+        assertEquals(11, SerializationUtilities.getSerializerTypeId(SimpleBackupProcessorSerializer.class, 10));
+        assertEquals(12, SerializationUtilities.getSerializerTypeId(HazelcastOffloadableEntryProcessorSerializer.class, 10));
+    }
+    @Test
+    public void SerializationUtilities_UNExpected_Serializer_with_explicit_typeIdBase_Test() {
+        assertThrowsExactly(IllegalStateException.class, () -> { int typeId = SerializationUtilities.getSerializerTypeId(ArrayBlockingQueueStreamSerializer.class, 10); });
+    }
+
+
+    // ************************************************************************************
+    // TYPE_ID BASE NOT CONFIGURED
+    // Variable Source  ::  NONE
+    // ************************************************************************************
+    @Test
+    @ClearSystemProperty(key = SerializationUtilities.TYPE_ID_BASE_PROP_NAME)
+    @ClearEnvironmentVariable(key = SerializationUtilities.TYPE_ID_BASE_PROP_NAME)
+    public void SerializationUtilities_TypeIdBase_Not_Configured_Test() {
+        assertThrowsExactly(MissingConfigurationParameterException.class, () -> { int typeId = SerializationUtilities.getSerializerTypeId(HazelcastEntryProcessorSerializer.class); });
+        assertThrowsExactly(MissingConfigurationParameterException.class, () -> { int typeId = SerializationUtilities.getSerializerTypeId(SimpleBackupProcessorSerializer.class); });
+        assertThrowsExactly(MissingConfigurationParameterException.class, () -> { int typeId = SerializationUtilities.getSerializerTypeId(HazelcastOffloadableEntryProcessorSerializer.class); });
+    }
+
+
+    // ************************************************************************************
+    // TYPE_ID BASE
+    // Variable Source  ::  ENVIRONMENT VARIABLES
+    // ************************************************************************************
+    @Test
+    @ClearSystemProperty(key = SerializationUtilities.TYPE_ID_BASE_PROP_NAME)
+    @SetEnvironmentVariable(key = SerializationUtilities.TYPE_ID_BASE_PROP_NAME, value = TYPE_ID_BASE_ENV_VAR_VALUE_VALID)
+    public void SerializationUtilities_TypeIdBase_Configured_Valid_As_Env_Test() {
+        assertEquals(TYPE_ID_BASE_ENV_VAR_VALUE_VALID, System.getenv(SerializationUtilities.TYPE_ID_BASE_PROP_NAME));
+
+        assertEquals(Integer.parseInt(TYPE_ID_BASE_ENV_VAR_VALUE_VALID)+0, SerializationUtilities.getSerializerTypeId(HazelcastEntryProcessorSerializer.class));
+        assertEquals(Integer.parseInt(TYPE_ID_BASE_ENV_VAR_VALUE_VALID)+1, SerializationUtilities.getSerializerTypeId(SimpleBackupProcessorSerializer.class));
+        assertEquals(Integer.parseInt(TYPE_ID_BASE_ENV_VAR_VALUE_VALID)+2, SerializationUtilities.getSerializerTypeId(HazelcastOffloadableEntryProcessorSerializer.class));
+    }
+    @Test
+    @ClearSystemProperty(key = SerializationUtilities.TYPE_ID_BASE_PROP_NAME)
+    @SetEnvironmentVariable(key = SerializationUtilities.TYPE_ID_BASE_PROP_NAME, value = TYPE_ID_BASE_ENV_VAR_VALUE_INVALID)
+    public void SerializationUtilities_TypeIdBase_Configured_Invalid_As_Env_Test() {
+        assertEquals(TYPE_ID_BASE_ENV_VAR_VALUE_INVALID, System.getenv(SerializationUtilities.TYPE_ID_BASE_PROP_NAME));
+
+        assertThrowsExactly(InvalidConfigurationParameterException.class, () -> { int typeId = SerializationUtilities.getSerializerTypeId(HazelcastEntryProcessorSerializer.class); });
+        assertThrowsExactly(InvalidConfigurationParameterException.class, () -> { int typeId = SerializationUtilities.getSerializerTypeId(SimpleBackupProcessorSerializer.class); });
+        assertThrowsExactly(InvalidConfigurationParameterException.class, () -> { int typeId = SerializationUtilities.getSerializerTypeId(HazelcastOffloadableEntryProcessorSerializer.class); });
+    }
+
+
+    // ************************************************************************************
+    // TYPE_ID BASE
+    // Variable Source  ::  SYSTEM PROPERTIES
+    // ************************************************************************************
+    @Test
+    @ClearEnvironmentVariable(key = SerializationUtilities.TYPE_ID_BASE_PROP_NAME)
+    @SetSystemProperty(key = SerializationUtilities.TYPE_ID_BASE_PROP_NAME, value = TYPE_ID_BASE_SYS_PROP_VALUE_VALID)
+    public void SerializationUtilities_TypeIdBase_Configured_Valid_As_SysProp_Test() {
+        assertEquals(TYPE_ID_BASE_SYS_PROP_VALUE_VALID, System.getProperty(SerializationUtilities.TYPE_ID_BASE_PROP_NAME));
+
+        assertEquals(Integer.parseInt(TYPE_ID_BASE_SYS_PROP_VALUE_VALID)+0, SerializationUtilities.getSerializerTypeId(HazelcastEntryProcessorSerializer.class));
+        assertEquals(Integer.parseInt(TYPE_ID_BASE_SYS_PROP_VALUE_VALID)+1, SerializationUtilities.getSerializerTypeId(SimpleBackupProcessorSerializer.class));
+        assertEquals(Integer.parseInt(TYPE_ID_BASE_SYS_PROP_VALUE_VALID)+2, SerializationUtilities.getSerializerTypeId(HazelcastOffloadableEntryProcessorSerializer.class));
+    }
+    @Test
+    @ClearEnvironmentVariable(key = SerializationUtilities.TYPE_ID_BASE_PROP_NAME)
+    @SetSystemProperty(key = SerializationUtilities.TYPE_ID_BASE_PROP_NAME, value = TYPE_ID_BASE_SYS_PROP_VALUE_INVALID)
+    public void SerializationUtilities_TypeIdBase_Configured_Invalid_As_SysProp_Test() {
+        assertEquals(TYPE_ID_BASE_SYS_PROP_VALUE_INVALID, System.getProperty(SerializationUtilities.TYPE_ID_BASE_PROP_NAME));
+
+        assertThrowsExactly(InvalidConfigurationParameterException.class, () -> { int typeId = SerializationUtilities.getSerializerTypeId(HazelcastEntryProcessorSerializer.class); });
+        assertThrowsExactly(InvalidConfigurationParameterException.class, () -> { int typeId = SerializationUtilities.getSerializerTypeId(SimpleBackupProcessorSerializer.class); });
+        assertThrowsExactly(InvalidConfigurationParameterException.class, () -> { int typeId = SerializationUtilities.getSerializerTypeId(HazelcastOffloadableEntryProcessorSerializer.class); });
+    }
+
+
+
+    // ************************************************************************************
+    // TYPE_ID BASE
+    // BOTH Variable Source simultaneously present
+    // ************************************************************************************
+    @Test
+    @SetEnvironmentVariable(key = SerializationUtilities.TYPE_ID_BASE_PROP_NAME, value = TYPE_ID_BASE_ENV_VAR_VALUE_VALID)
+    @SetSystemProperty(key = SerializationUtilities.TYPE_ID_BASE_PROP_NAME, value = TYPE_ID_BASE_SYS_PROP_VALUE_VALID)
+    public void SerializationUtilities_TypeIdBase_Configured_Valid_SysProp_Valid_EnvVar_Test() {
+        assertEquals(TYPE_ID_BASE_ENV_VAR_VALUE_VALID, System.getenv(SerializationUtilities.TYPE_ID_BASE_PROP_NAME));
+        assertEquals(TYPE_ID_BASE_SYS_PROP_VALUE_VALID, System.getProperty(SerializationUtilities.TYPE_ID_BASE_PROP_NAME));
+
+        assertEquals(Integer.parseInt(TYPE_ID_BASE_SYS_PROP_VALUE_VALID)+0, SerializationUtilities.getSerializerTypeId(HazelcastEntryProcessorSerializer.class));
+        assertEquals(Integer.parseInt(TYPE_ID_BASE_SYS_PROP_VALUE_VALID)+1, SerializationUtilities.getSerializerTypeId(SimpleBackupProcessorSerializer.class));
+        assertEquals(Integer.parseInt(TYPE_ID_BASE_SYS_PROP_VALUE_VALID)+2, SerializationUtilities.getSerializerTypeId(HazelcastOffloadableEntryProcessorSerializer.class));
+    }
+
+    @Test
+    @SetEnvironmentVariable(key = SerializationUtilities.TYPE_ID_BASE_PROP_NAME, value = TYPE_ID_BASE_ENV_VAR_VALUE_INVALID)
+    @SetSystemProperty(key = SerializationUtilities.TYPE_ID_BASE_PROP_NAME, value = TYPE_ID_BASE_SYS_PROP_VALUE_VALID)
+    public void SerializationUtilities_TypeIdBase_Configured_Valid_SysProp_INValid_EnvVar_Test() {
+        assertEquals(TYPE_ID_BASE_ENV_VAR_VALUE_INVALID, System.getenv(SerializationUtilities.TYPE_ID_BASE_PROP_NAME));
+        assertEquals(TYPE_ID_BASE_SYS_PROP_VALUE_VALID, System.getProperty(SerializationUtilities.TYPE_ID_BASE_PROP_NAME));
+
+        assertEquals(Integer.parseInt(TYPE_ID_BASE_SYS_PROP_VALUE_VALID)+0, SerializationUtilities.getSerializerTypeId(HazelcastEntryProcessorSerializer.class));
+        assertEquals(Integer.parseInt(TYPE_ID_BASE_SYS_PROP_VALUE_VALID)+1, SerializationUtilities.getSerializerTypeId(SimpleBackupProcessorSerializer.class));
+        assertEquals(Integer.parseInt(TYPE_ID_BASE_SYS_PROP_VALUE_VALID)+2, SerializationUtilities.getSerializerTypeId(HazelcastOffloadableEntryProcessorSerializer.class));
+    }
+
+    @Test
+    @SetEnvironmentVariable(key = SerializationUtilities.TYPE_ID_BASE_PROP_NAME, value = TYPE_ID_BASE_ENV_VAR_VALUE_VALID)
+    @SetSystemProperty(key = SerializationUtilities.TYPE_ID_BASE_PROP_NAME, value = TYPE_ID_BASE_SYS_PROP_VALUE_INVALID)
+    public void SerializationUtilities_TypeIdBase_Configured_INValid_SysProp_Valid_EnvVar_Test() {
+        assertEquals(TYPE_ID_BASE_ENV_VAR_VALUE_VALID, System.getenv(SerializationUtilities.TYPE_ID_BASE_PROP_NAME));
+        assertEquals(TYPE_ID_BASE_SYS_PROP_VALUE_INVALID, System.getProperty(SerializationUtilities.TYPE_ID_BASE_PROP_NAME));
+
+        assertThrowsExactly(InvalidConfigurationParameterException.class, () -> { int typeId = SerializationUtilities.getSerializerTypeId(HazelcastEntryProcessorSerializer.class); });
+        assertThrowsExactly(InvalidConfigurationParameterException.class, () -> { int typeId = SerializationUtilities.getSerializerTypeId(SimpleBackupProcessorSerializer.class); });
+        assertThrowsExactly(InvalidConfigurationParameterException.class, () -> { int typeId = SerializationUtilities.getSerializerTypeId(HazelcastOffloadableEntryProcessorSerializer.class); });
+    }
+
+    @Test
+    @SetEnvironmentVariable(key = SerializationUtilities.TYPE_ID_BASE_PROP_NAME, value = TYPE_ID_BASE_ENV_VAR_VALUE_INVALID)
+    @SetSystemProperty(key = SerializationUtilities.TYPE_ID_BASE_PROP_NAME, value = TYPE_ID_BASE_SYS_PROP_VALUE_INVALID)
+    public void SerializationUtilities_TypeIdBase_Configured_INValid_SysProp_INValid_EnvVar_Test() {
+        assertEquals(TYPE_ID_BASE_ENV_VAR_VALUE_INVALID, System.getenv(SerializationUtilities.TYPE_ID_BASE_PROP_NAME));
+        assertEquals(TYPE_ID_BASE_SYS_PROP_VALUE_INVALID, System.getProperty(SerializationUtilities.TYPE_ID_BASE_PROP_NAME));
+
+        assertThrowsExactly(InvalidConfigurationParameterException.class, () -> { int typeId = SerializationUtilities.getSerializerTypeId(HazelcastEntryProcessorSerializer.class); });
+        assertThrowsExactly(InvalidConfigurationParameterException.class, () -> { int typeId = SerializationUtilities.getSerializerTypeId(SimpleBackupProcessorSerializer.class); });
+        assertThrowsExactly(InvalidConfigurationParameterException.class, () -> { int typeId = SerializationUtilities.getSerializerTypeId(HazelcastOffloadableEntryProcessorSerializer.class); });
+    }
+
+
+}


### PR DESCRIPTION
As suggested by @vladimir-bukhtoyarov during the discussion on the Issue #477 I'm submitting a PR to enable the loading of the Bucke4j custom serializers through the Hazelcast standard configuration file instead of the need to do it programmatically.

A quick disclaimer:
I'm not a skilled java guy and this is the first Spring-less project I'm working on since the University, and I was used to play the brand new "**Legend of Zelda: Ocarina of time**" at that times!

This PR includes:
- a new static class `SerializationUtility` where I put all the logic to retrieve the typeIdBase based on System Properties or Environment Variables and compute all the typeId for the well-known Serializers based on the offsets declared statically
- a new parameterless ctor in all ther three well-known Serializers to allow them being used in the hazelcast configuration file with just their name
- a new JTest class to test the `SerializationUtility` helper
- a new JTest class (cloned by the already existing `HazelcastWithCustomSerializersTest` with a different loading of the hazlecast server using the same hazelcast config primitives used by hazelcast when it loads from configuration file.
- a new **test** dependency to help adding Env Var during tests