### PR TITLE
Fix reset() to skip unnecessary token recalculation

### DIFF
--- a/bucket4j-core/src/main/java/io/github/bucket4j/BucketState.java
+++ b/bucket4j-core/src/main/java/io/github/bucket4j/BucketState.java
@@ -61,6 +61,8 @@ public interface BucketState {
 
     MathType getMathType();
 
+    void setRefillTime(long currentTimeNano);
+
     static BucketState createInitialState(BucketConfiguration configuration, MathType mathType, long currentTimeNanos) {
         return switch (mathType) {
             case INTEGER_64_BITS -> new BucketState64BitsInteger(configuration, currentTimeNanos);

--- a/bucket4j-core/src/main/java/io/github/bucket4j/BucketState.java
+++ b/bucket4j-core/src/main/java/io/github/bucket4j/BucketState.java
@@ -61,7 +61,7 @@ public interface BucketState {
 
     MathType getMathType();
 
-    void setRefillTime(long currentTimeNano);
+    void syncRefillTimestamps(long currentTimeNanos);
 
     static BucketState createInitialState(BucketConfiguration configuration, MathType mathType, long currentTimeNanos) {
         return switch (mathType) {

--- a/bucket4j-core/src/main/java/io/github/bucket4j/BucketState64BitsInteger.java
+++ b/bucket4j-core/src/main/java/io/github/bucket4j/BucketState64BitsInteger.java
@@ -653,27 +653,27 @@ public class BucketState64BitsInteger implements BucketState, ComparableByConten
     }
 
     @Override
-    public void setRefillTime(long currentTimeNano) {
+    public void syncRefillTimestamps(long currentTimeNanos) {
         Bandwidth[] bandwidths = configuration.getBandwidths();
         for(int i = 0; i < bandwidths.length; i++){
-            long refillTime = normalizeRefillTime(i, bandwidths[i], currentTimeNano);
+            long refillTime = normalizeRefillTime(i, bandwidths[i], currentTimeNanos);
             if(refillTime != -1L)
                 setLastRefillTimeNanos(i, refillTime);
         }
     }
 
-    private long normalizeRefillTime(int bandwidthIndex, Bandwidth bandwidth, long currentTimeToNanos){
+    private long normalizeRefillTime(int bandwidthIndex, Bandwidth bandwidth, long currentTimeNanos){
         long previousRefillNanos = getLastRefillTimeNanos(bandwidthIndex);
-        if(currentTimeToNanos <= previousRefillNanos)
-            return -1;
+        if(currentTimeNanos <= previousRefillNanos)
+            return -1L;
         if(bandwidth.isRefillIntervally()){
-            long correction = (currentTimeToNanos - previousRefillNanos)%bandwidth.getRefillPeriodNanos();
-            currentTimeToNanos -= currentTimeToNanos;
+            long correction = (currentTimeNanos - previousRefillNanos)%bandwidth.getRefillPeriodNanos();
+            currentTimeNanos -= correction;
         }
 
-        if(currentTimeToNanos <= previousRefillNanos)
-            return -1;
-        return currentTimeToNanos;
+        if(currentTimeNanos <= previousRefillNanos)
+            return -1L;
+        return currentTimeNanos;
     }
 
 }

--- a/bucket4j-core/src/main/java/io/github/bucket4j/BucketState64BitsInteger.java
+++ b/bucket4j-core/src/main/java/io/github/bucket4j/BucketState64BitsInteger.java
@@ -446,19 +446,12 @@ public class BucketState64BitsInteger implements BucketState, ComparableByConten
 
     private void refill(int bandwidthIndex, Bandwidth bandwidth, long currentTimeNanos) {
         long previousRefillNanos = getLastRefillTimeNanos(bandwidthIndex);
-        if (currentTimeNanos <= previousRefillNanos) {
-            return;
-        }
+        currentTimeNanos = normalizeRefillTime(bandwidthIndex, bandwidth, currentTimeNanos);
 
-        if (bandwidth.isRefillIntervally()) {
-            long incompleteIntervalCorrection = (currentTimeNanos - previousRefillNanos) % bandwidth.getRefillPeriodNanos();
-            currentTimeNanos -= incompleteIntervalCorrection;
-        }
-        if (currentTimeNanos <= previousRefillNanos) {
+        if(currentTimeNanos == -1L)
             return;
-        } else {
-            setLastRefillTimeNanos(bandwidthIndex, currentTimeNanos);
-        }
+
+        setLastRefillTimeNanos(bandwidthIndex, currentTimeNanos);
 
         final long capacity = bandwidth.getCapacity();
         final long refillPeriodNanos = bandwidth.getRefillPeriodNanos();
@@ -657,6 +650,30 @@ public class BucketState64BitsInteger implements BucketState, ComparableByConten
     @Override
     public boolean equalsByContent(BucketState64BitsInteger other) {
         return Arrays.equals(stateData, other.stateData);
+    }
+
+    @Override
+    public void setRefillTime(long currentTimeNano) {
+        Bandwidth[] bandwidths = configuration.getBandwidths();
+        for(int i = 0; i < bandwidths.length; i++){
+            long refillTime = normalizeRefillTime(i, bandwidths[i], currentTimeNano);
+            if(refillTime != -1L)
+                setLastRefillTimeNanos(i, refillTime);
+        }
+    }
+
+    private long normalizeRefillTime(int bandwidthIndex, Bandwidth bandwidth, long currentTimeToNanos){
+        long previousRefillNanos = getLastRefillTimeNanos(bandwidthIndex);
+        if(currentTimeToNanos <= previousRefillNanos)
+            return -1;
+        if(bandwidth.isRefillIntervally()){
+            long correction = (currentTimeToNanos - previousRefillNanos)%bandwidth.getRefillPeriodNanos();
+            currentTimeToNanos -= currentTimeToNanos;
+        }
+
+        if(currentTimeToNanos <= previousRefillNanos)
+            return -1;
+        return currentTimeToNanos;
     }
 
 }

--- a/bucket4j-core/src/main/java/io/github/bucket4j/distributed/remote/RemoteBucketState.java
+++ b/bucket4j-core/src/main/java/io/github/bucket4j/distributed/remote/RemoteBucketState.java
@@ -155,6 +155,10 @@ public class RemoteBucketState implements ComparableByContent<RemoteBucketState>
         state.refillAllBandwidth(currentTimeNanos);
     }
 
+    public void syncRefillTimestamps(long currentTimeNanos) {
+        state.syncRefillTimestamps(currentTimeNanos);
+    }
+
     public long getAvailableTokens() {
         return state.getAvailableTokens();
     }

--- a/bucket4j-core/src/main/java/io/github/bucket4j/distributed/remote/commands/ResetCommand.java
+++ b/bucket4j-core/src/main/java/io/github/bucket4j/distributed/remote/commands/ResetCommand.java
@@ -98,7 +98,7 @@ public class ResetCommand implements RemoteCommand<Nothing>, ComparableByContent
         }
 
         RemoteBucketState state = mutableEntry.get();
-        state.refillAllBandwidth(currentTimeNanos);
+        state.syncRefillTimestamps(currentTimeNanos);
         state.reset();
         mutableEntry.set(state);
         return CommandResult.empty();

--- a/bucket4j-core/src/main/java/io/github/bucket4j/local/LockFreeBucket.java
+++ b/bucket4j-core/src/main/java/io/github/bucket4j/local/LockFreeBucket.java
@@ -154,17 +154,15 @@ public class LockFreeBucket extends AbstractBucket implements LocalBucket, Compa
         while (true) {
             newState.refillAllBandwidth(currentTimeNanos);
             long nanosToCloseRefill = newState.calculateDelayNanosAfterWillBePossibleToConsume(tokensToConsume, currentTimeNanos, false);
-            if (nanosToCloseRefill <= waitIfBusyNanosLimit) {
-                newState.consume(tokensToConsume);
-                if (stateRef.compareAndSet(previousState, newState)) {
-                    return nanosToCloseRefill;
-                }
-                previousState = stateRef.get();
-                newState.copyStateFrom(previousState);
-            }
-            if (nanosToCloseRefill == Long.MAX_VALUE) {
+            if (nanosToCloseRefill > waitIfBusyNanosLimit) {
                 return Long.MAX_VALUE;
             }
+            newState.consume(tokensToConsume);
+            if (stateRef.compareAndSet(previousState, newState)) {
+                return nanosToCloseRefill;
+            }
+            previousState = stateRef.get();
+            newState.copyStateFrom(previousState);
         }
     }
 
@@ -177,17 +175,15 @@ public class LockFreeBucket extends AbstractBucket implements LocalBucket, Compa
         while (true) {
             newState.refillAllBandwidth(currentTimeNanos);
             long nanosToCloseDeficit = newState.calculateDelayNanosAfterWillBePossibleToConsume(tokensToConsume, currentTimeNanos, false);
-            if (nanosToCloseDeficit <= maxWaitTimeNanos) {
-                newState.consume(tokensToConsume);
-                if (stateRef.compareAndSet(previousState, newState)) {
-                    return new VerboseResult<>(currentTimeNanos, nanosToCloseDeficit, newState.copy());
-                }
-                previousState = stateRef.get();
-                newState.copyStateFrom(previousState);
+            if (nanosToCloseDeficit > maxWaitTimeNanos) {
+                return new VerboseResult<>(currentTimeNanos, Long.MAX_VALUE, newState.copy());
             }
-            if (nanosToCloseDeficit == Long.MAX_VALUE) {
-                return new VerboseResult<>(Long.MAX_VALUE, nanosToCloseDeficit, newState.copy());
+            newState.consume(tokensToConsume);
+            if (stateRef.compareAndSet(previousState, newState)) {
+                return new VerboseResult<>(currentTimeNanos, nanosToCloseDeficit, newState.copy());
             }
+            previousState = stateRef.get();
+            newState.copyStateFrom(previousState);
         }
     }
 

--- a/bucket4j-core/src/main/java/io/github/bucket4j/local/LockFreeBucket.java
+++ b/bucket4j-core/src/main/java/io/github/bucket4j/local/LockFreeBucket.java
@@ -234,7 +234,7 @@ public class LockFreeBucket extends AbstractBucket implements LocalBucket, Compa
         long currentTimeNanos = timeMeter.currentTimeNanos();
 
         while (true) {
-            newState.setRefillTime(currentTimeNanos);
+            newState.syncRefillTimestamps(currentTimeNanos);
             newState.reset();
             if (stateRef.compareAndSet(previousState, newState)) {
                 return;
@@ -427,7 +427,7 @@ public class LockFreeBucket extends AbstractBucket implements LocalBucket, Compa
         long currentTimeNanos = timeMeter.currentTimeNanos();
 
         while (true) {
-            newState.setRefillTime(currentTimeNanos);
+            newState.syncRefillTimestamps(currentTimeNanos);
             newState.reset();
             if (stateRef.compareAndSet(previousState, newState)) {
                 return new VerboseResult<>(currentTimeNanos, Nothing.INSTANCE, newState.copy());

--- a/bucket4j-core/src/main/java/io/github/bucket4j/local/LockFreeBucket.java
+++ b/bucket4j-core/src/main/java/io/github/bucket4j/local/LockFreeBucket.java
@@ -153,13 +153,24 @@ public class LockFreeBucket extends AbstractBucket implements LocalBucket, Compa
 
         while (true) {
             newState.refillAllBandwidth(currentTimeNanos);
-            long nanosToCloseRefill = newState.calculateDelayNanosAfterWillBePossibleToConsume(tokensToConsume, currentTimeNanos, false);
-            if (nanosToCloseRefill > waitIfBusyNanosLimit) {
+            long nanosToCloseDeficit = newState.calculateDelayNanosAfterWillBePossibleToConsume(tokensToConsume, currentTimeNanos, false);
+            if (nanosToCloseDeficit == 0) {
+                newState.consume(tokensToConsume);
+                if (stateRef.compareAndSet(previousState, newState)) {
+                    return 0L;
+                }
+                previousState = stateRef.get();
+                newState.copyStateFrom(previousState);
+                continue;
+            }
+
+            if (nanosToCloseDeficit == Long.MAX_VALUE || nanosToCloseDeficit > waitIfBusyNanosLimit) {
                 return Long.MAX_VALUE;
             }
+
             newState.consume(tokensToConsume);
             if (stateRef.compareAndSet(previousState, newState)) {
-                return nanosToCloseRefill;
+                return nanosToCloseDeficit;
             }
             previousState = stateRef.get();
             newState.copyStateFrom(previousState);
@@ -175,8 +186,14 @@ public class LockFreeBucket extends AbstractBucket implements LocalBucket, Compa
         while (true) {
             newState.refillAllBandwidth(currentTimeNanos);
             long nanosToCloseDeficit = newState.calculateDelayNanosAfterWillBePossibleToConsume(tokensToConsume, currentTimeNanos, false);
-            if (nanosToCloseDeficit > maxWaitTimeNanos) {
-                return new VerboseResult<>(currentTimeNanos, Long.MAX_VALUE, newState.copy());
+            if (nanosToCloseDeficit == 0) {
+                newState.consume(tokensToConsume);
+                if (stateRef.compareAndSet(previousState, newState)) {
+                    return new VerboseResult<>(currentTimeNanos, 0L, newState.copy());
+                }
+                previousState = stateRef.get();
+                newState.copyStateFrom(previousState);
+                continue;
             }
             newState.consume(tokensToConsume);
             if (stateRef.compareAndSet(previousState, newState)) {

--- a/bucket4j-core/src/main/java/io/github/bucket4j/local/LockFreeBucket.java
+++ b/bucket4j-core/src/main/java/io/github/bucket4j/local/LockFreeBucket.java
@@ -153,27 +153,18 @@ public class LockFreeBucket extends AbstractBucket implements LocalBucket, Compa
 
         while (true) {
             newState.refillAllBandwidth(currentTimeNanos);
-            long nanosToCloseDeficit = newState.calculateDelayNanosAfterWillBePossibleToConsume(tokensToConsume, currentTimeNanos, false);
-            if (nanosToCloseDeficit == 0) {
+            long nanosToCloseRefill = newState.calculateDelayNanosAfterWillBePossibleToConsume(tokensToConsume, currentTimeNanos, false);
+            if (nanosToCloseRefill <= waitIfBusyNanosLimit) {
                 newState.consume(tokensToConsume);
                 if (stateRef.compareAndSet(previousState, newState)) {
-                    return 0L;
+                    return nanosToCloseRefill;
                 }
                 previousState = stateRef.get();
                 newState.copyStateFrom(previousState);
-                continue;
             }
-
-            if (nanosToCloseDeficit == Long.MAX_VALUE || nanosToCloseDeficit > waitIfBusyNanosLimit) {
+            if (nanosToCloseRefill == Long.MAX_VALUE) {
                 return Long.MAX_VALUE;
             }
-
-            newState.consume(tokensToConsume);
-            if (stateRef.compareAndSet(previousState, newState)) {
-                return nanosToCloseDeficit;
-            }
-            previousState = stateRef.get();
-            newState.copyStateFrom(previousState);
         }
     }
 
@@ -186,26 +177,17 @@ public class LockFreeBucket extends AbstractBucket implements LocalBucket, Compa
         while (true) {
             newState.refillAllBandwidth(currentTimeNanos);
             long nanosToCloseDeficit = newState.calculateDelayNanosAfterWillBePossibleToConsume(tokensToConsume, currentTimeNanos, false);
-            if (nanosToCloseDeficit == 0) {
+            if (nanosToCloseDeficit <= maxWaitTimeNanos) {
                 newState.consume(tokensToConsume);
                 if (stateRef.compareAndSet(previousState, newState)) {
-                    return new VerboseResult<>(currentTimeNanos, 0L, newState.copy());
+                    return new VerboseResult<>(currentTimeNanos, nanosToCloseDeficit, newState.copy());
                 }
                 previousState = stateRef.get();
                 newState.copyStateFrom(previousState);
-                continue;
             }
-
-            if (nanosToCloseDeficit == Long.MAX_VALUE || nanosToCloseDeficit > maxWaitTimeNanos) {
-                return new VerboseResult<>(currentTimeNanos, Long.MAX_VALUE, newState);
+            if (nanosToCloseDeficit == Long.MAX_VALUE) {
+                return new VerboseResult<>(Long.MAX_VALUE, nanosToCloseDeficit, newState.copy());
             }
-
-            newState.consume(tokensToConsume);
-            if (stateRef.compareAndSet(previousState, newState)) {
-                return new VerboseResult<>(currentTimeNanos, nanosToCloseDeficit, newState.copy());
-            }
-            previousState = stateRef.get();
-            newState.copyStateFrom(previousState);
         }
     }
 
@@ -252,7 +234,7 @@ public class LockFreeBucket extends AbstractBucket implements LocalBucket, Compa
         long currentTimeNanos = timeMeter.currentTimeNanos();
 
         while (true) {
-            newState.refillAllBandwidth(currentTimeNanos);
+            newState.setRefillTime(currentTimeNanos);
             newState.reset();
             if (stateRef.compareAndSet(previousState, newState)) {
                 return;
@@ -445,7 +427,7 @@ public class LockFreeBucket extends AbstractBucket implements LocalBucket, Compa
         long currentTimeNanos = timeMeter.currentTimeNanos();
 
         while (true) {
-            newState.refillAllBandwidth(currentTimeNanos);
+            newState.setRefillTime(currentTimeNanos);
             newState.reset();
             if (stateRef.compareAndSet(previousState, newState)) {
                 return new VerboseResult<>(currentTimeNanos, Nothing.INSTANCE, newState.copy());

--- a/bucket4j-core/src/main/java/io/github/bucket4j/local/SynchronizedBucket.java
+++ b/bucket4j-core/src/main/java/io/github/bucket4j/local/SynchronizedBucket.java
@@ -320,7 +320,7 @@ public class SynchronizedBucket extends AbstractBucket implements LocalBucket, C
         long currentTimeNanos = timeMeter.currentTimeNanos();
         lock.lock();
         try {
-            state.refillAllBandwidth(currentTimeNanos);
+            state.syncRefillTimestamps(currentTimeNanos);
             state.reset();
             return new VerboseResult<>(currentTimeNanos, Nothing.INSTANCE, state.copy());
         } finally {
@@ -389,7 +389,7 @@ public class SynchronizedBucket extends AbstractBucket implements LocalBucket, C
         long currentTimeNanos = timeMeter.currentTimeNanos();
         lock.lock();
         try {
-            state.refillAllBandwidth(currentTimeNanos);
+            state.syncRefillTimestamps(currentTimeNanos);
             state.reset();
         } finally {
             lock.unlock();

--- a/bucket4j-core/src/main/java/io/github/bucket4j/local/ThreadUnsafeBucket.java
+++ b/bucket4j-core/src/main/java/io/github/bucket4j/local/ThreadUnsafeBucket.java
@@ -240,7 +240,7 @@ public class ThreadUnsafeBucket extends AbstractBucket implements LocalBucket, C
     @Override
     protected VerboseResult<Nothing> resetVerboseImpl() {
         long currentTimeNanos = timeMeter.currentTimeNanos();
-        state.refillAllBandwidth(currentTimeNanos);
+        state.syncRefillTimestamps(currentTimeNanos);
         state.reset();
         return new VerboseResult<>(currentTimeNanos, Nothing.INSTANCE, state.copy());
     }
@@ -284,7 +284,7 @@ public class ThreadUnsafeBucket extends AbstractBucket implements LocalBucket, C
     @Override
     public void reset() {
         long currentTimeNanos = timeMeter.currentTimeNanos();
-        state.refillAllBandwidth(currentTimeNanos);
+        state.syncRefillTimestamps(currentTimeNanos);
         state.reset();
     }
 


### PR DESCRIPTION
## What's changed

### Improvement — reset() no longer does unnecessary work
Before this change, calling `reset()` on a bucket would first call
`refillAllBandwidth()`, which recalculates how many tokens each bandwidth
should have based on elapsed time — and then immediately throw that work
away since `reset()` restores tokens to full capacity regardless.

Introduced a new method `syncRefillTimestamps()` on the `BucketState`
interface that only updates the refill timestamps without touching token
counts. This is all that's needed before a reset.

Applied across all three local bucket implementations and the distributed
reset command:
- `LockFreeBucket`
- `SynchronizedBucket`
- `ThreadUnsafeBucket`
- `ResetCommand` (distributed)

### No behaviour change for callers.

@vladimir-bukhtoyarov thanks for such a awesome library