### PR TITLE
bucket4j (lettuce) support for redis with sentinel

### DIFF
--- a/bucket4j-redis/bucket4j-lettuce/src/main/java/io/github/bucket4j/redis/lettuce/Bucket4jLettuce.java
+++ b/bucket4j-redis/bucket4j-lettuce/src/main/java/io/github/bucket4j/redis/lettuce/Bucket4jLettuce.java
@@ -32,6 +32,7 @@ import io.lettuce.core.cluster.RedisClusterClient;
 import io.lettuce.core.cluster.api.StatefulRedisClusterConnection;
 import io.lettuce.core.cluster.api.async.RedisAdvancedClusterAsyncCommands;
 import io.lettuce.core.codec.ByteArrayCodec;
+import io.lettuce.core.masterreplica.StatefulRedisMasterReplicaConnection;
 
 /**
  * Entry point for Lettuce integration
@@ -63,6 +64,17 @@ public class Bucket4jLettuce {
             }
         };
         return new LettuceBasedProxyManagerBuilder<>(redisApi);
+    }
+
+    /**
+     * Returns the builder for {@link LettuceBasedProxyManager}
+     *
+     * @param statefulRedisMasterReplicaConnection
+     *
+     * @return new instance of {@link LettuceBasedProxyManagerBuilder}
+     */
+    public static <K> LettuceBasedProxyManagerBuilder<K> casBasedBuilder(StatefulRedisMasterReplicaConnection<K, byte[]> statefulRedisMasterReplicaConnection) {
+       return casBasedBuilder(statefulRedisMasterReplicaConnection.async());
     }
 
     /**

--- a/bucket4j-redis/bucket4j-lettuce/src/test/java/io/github/bucket4j/redis/LettuceBasedProxyManagerSentinelTest.java
+++ b/bucket4j-redis/bucket4j-lettuce/src/test/java/io/github/bucket4j/redis/LettuceBasedProxyManagerSentinelTest.java
@@ -1,0 +1,106 @@
+package io.github.bucket4j.redis;
+
+import java.util.Arrays;
+import java.util.UUID;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.testcontainers.containers.GenericContainer;
+
+import io.github.bucket4j.redis.lettuce.Bucket4jLettuce;
+import io.github.bucket4j.tck.AbstractDistributedBucketTest;
+import io.github.bucket4j.tck.ProxyManagerSpec;
+import io.lettuce.core.RedisClient;
+import io.lettuce.core.RedisURI;
+import io.lettuce.core.codec.ByteArrayCodec;
+import io.lettuce.core.codec.RedisCodec;
+import io.lettuce.core.codec.StringCodec;
+import io.lettuce.core.masterreplica.MasterReplica;
+import io.lettuce.core.masterreplica.StatefulRedisMasterReplicaConnection;
+
+public class LettuceBasedProxyManagerSentinelTest extends AbstractDistributedBucketTest {
+
+    private static GenericContainer redisContainer;
+    private static GenericContainer sentinelContainer;
+    private static RedisClient redisClient;
+    private static StatefulRedisMasterReplicaConnection<String, byte[]> redisConnection;
+
+    @BeforeAll
+    public static void setup() {
+
+        redisContainer = new GenericContainer("redis:4.0.11")
+                .withExposedPorts(6379);
+        redisContainer.start();
+
+        Integer redisPort = redisContainer.getMappedPort(6379);
+
+        sentinelContainer = new GenericContainer("redis:4.0.11")
+                .withExposedPorts(26379)
+                .withCommand(
+                        "sh", "-c",
+                        "echo 'port 26379\nsentinel monitor mymaster 127.0.0.1 " + redisPort + " 1\nsentinel down-after-milliseconds mymaster 3000' > /tmp/sentinel.conf && redis-server /tmp/sentinel.conf --sentinel"
+                );
+        sentinelContainer.start();
+
+        Integer sentinelPort = sentinelContainer.getMappedPort(26379);
+
+        // 3. Setup the Sentinel URI directly against the IPv4 address
+        RedisURI sentinelUri = RedisURI.builder()
+                .withSentinelMasterId("mymaster")
+                .withSentinel("127.0.0.1", sentinelPort)
+                .build();
+
+        redisClient = RedisClient.create(sentinelUri);
+        RedisCodec<String, byte[]> bucket4jCodec = RedisCodec.of(StringCodec.UTF8, ByteArrayCodec.INSTANCE);
+
+        // Establish the MasterReplica (topology aware connection context exactly once)
+        redisConnection = MasterReplica.connect(redisClient, bucket4jCodec, sentinelUri);
+
+        long startTime = System.currentTimeMillis();
+        while (System.currentTimeMillis() - startTime < 5000) {
+            try {
+                // Perform a lightweight ping over the topology interface to check if Master is resolved
+                redisConnection.sync().ping();
+                break; // Connection is fully topology-aware
+            } catch (Exception e) {
+                try {
+                    Thread.sleep(200); //allow some time for the thread to wait until leader election
+                } catch (InterruptedException ie) {
+                    Thread.currentThread().interrupt();
+                }
+            }
+        }
+
+        specs = Arrays.asList(
+                new ProxyManagerSpec<>(
+                        "LettuceBasedProxyManager_Sentinel_StringKey",
+                        () -> UUID.randomUUID().toString(),
+                        () -> Bucket4jLettuce.casBasedBuilder(redisConnection)
+                ).checkExpiration()
+        );
+    }
+
+    @AfterAll
+    public static void shutdown() {
+        try {
+            if (redisConnection != null) {
+                redisConnection.close();
+            }
+        } finally {
+            try {
+                if (redisClient != null) {
+                    redisClient.shutdown();
+                }
+            } finally {
+                try {
+                    if (sentinelContainer != null) {
+                        sentinelContainer.close();
+                    }
+                } finally {
+                    if (redisContainer != null) {
+                        redisContainer.close();
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Adds support for Lettuce StatefulRedisMasterReplicaConnection for improved Redis Sentinel failover handling.

## Motivation

Some users reported application freezes or failed reconnection behavior after Redis Sentinel failover while using StatefulRedisConnection. This PR introduces a builder supporting StatefulRedisMasterReplicaConnection that provides a topology aware redis-sentinel connection. 

## Testing

Empirical Load Testing & Proof (Apache Bench)

To isolate this behavior, I performed multi-threaded stress testing (`ab -n 10000 -c 10`) against a local 3-node Sentinel Docker cluster under a stable **12-second command timeout** window. The master node was intentionally stopped mid-test. (rithraravikumar@Rithras-MacBook-Air redis-sentinel-lab % docker stop redis-master
redis-master)

### Test A: Standard `StatefulRedisConnection` (The Bug)

* **Result:** **Failed / Timed Out** at request 3,794. 
* **Metrics:** 

> rithraravikumar@Rithras-MacBook-Air redis-sentinel-lab % ab -n 10000 -c 10 http://localhost:8080/test
> This is ApacheBench, Version 2.3 <$Revision: 1903618 $>
> Copyright 1996 Adam Twiss, Zeus Technology Ltd, http://www.zeustech.net/
> Licensed to The Apache Software Foundation, http://www.apache.org/
> 
> Benchmarking localhost (be patient)
> Completed 1000 requests
> Completed 2000 requests
> Completed 3000 requests
> apr_pollset_poll: The timeout specified has expired (70007)
> Total of 3794 requests completed

_Benchmarking localhost (be patient)_ **_Thread froze at this point even after the master was re-voted and elected_**
  Total of 3794 requests completed

**Observation**: Despite a generous 12-second timeout, the connection spent the entire duration knocking on the dead port, leading to an immediate overflow of the command buffer and a frozen application pool.

### Test B: Switch to `StatefulRedisMasterReplicaConnection` (Sentinel support)
* **Result:** **There was a stall while the reconnection happened, but after re-election test thread **_resumed and completed successfuly_**
* **Metrics:** 

> rithraravikumar@Rithras-MacBook-Air redis-sentinel-lab % ab -n 10000 -c 10 http://localhost:8080/test
> This is ApacheBench, Version 2.3 <$Revision: 1903618 $>
> Copyright 1996 Adam Twiss, Zeus Technology Ltd, http://www.zeustech.net/
> Licensed to The Apache Software Foundation, http://www.apache.org/
> 
> Benchmarking localhost (be patient)
> Completed 1000 requests
> Completed 2000 requests
> Completed 3000 requests
> Completed 4000 requests
> Completed 5000 requests
> Completed 6000 requests
> Completed 7000 requests
> Completed 8000 requests
> Completed 9000 requests
> Completed 10000 requests
> Finished 10000 requests
> 
> 
> Server Software:        
> Server Hostname:        localhost
> Server Port:            8080
> 
> Percentage of the requests served within a certain time (ms)
>   50%      1
>   66%      2
>   75%      3
>   80%      3
>   90%      7
>   95%     11
>   98%     19
>   99%     27
>  100%  21235 (longest request)
> rithraravikumar@Rithras-MacBook-Air redis-sentinel-lab

**Observation**: In the same 12-second timeout configured per my setup, the test thread was able to resume operation once the slave was promoted to master and re-elected. **_The thread did not stay frozen until timeout_**

**Note:** I omitted adding a formal integration test case to keep the repository CI footprint lightweight, as a reliable Sentinel failover integration test requires an orchestrated multi-node container environment not currently mirrored in the standalone or cluster test layouts. The fix has been rigorously verified via the local high-concurrency stress tests outlined above